### PR TITLE
#33 Feature/admin addons page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,24 @@
 # Better Sharing WP
+
 This WordPress plugin is to be used with your CloudSponge account.
 
 ## Requirements
-* WordPress
-* Node / NPM
-* Composer
+
+- WordPress
+- Node / NPM
+- Composer
 
 ## Installation
-* Install using one our pre-zipped releases  
-\- __OR__ -  
-* Clone repo into `wp-content/plugins`
-* Run `npm install && composer install && npm run build-dev`
-* Activate plugin via WordPress admin
+
+- Install using one our pre-zipped releases  
+  \- **OR** -
+- Clone repo into `wp-content/plugins`
+- Run `npm install && composer install && npm run build`
+- Activate plugin via WordPress admin
+
+## Develompent
+
+Follow Installation instructions then run `npm run start`
 
 ## AddOns
 

--- a/admin-assets/admin.js
+++ b/admin-assets/admin.js
@@ -24,7 +24,7 @@ class BSWPAdminJS {
       return false;
     }
 
-    if ("inactive" === pluginActive) {
+    if ("plugin-unavailable" === pluginActive) {
       alert(
         "Plugin is not installed & activated. Go to the Plugins page to activate the appropriate plugin"
       );

--- a/admin-assets/bs-wp-admin.scss
+++ b/admin-assets/bs-wp-admin.scss
@@ -184,8 +184,8 @@ $bswp-status-indicator-size: 1.5rem;
     }
 
     &__status-indicator {
-      position: relative;
       cursor: pointer;
+      position: relative;
       width: $bswp-status-indicator-size * 2;
       height: $bswp-status-indicator-size;
       border-radius: 3rem;
@@ -201,6 +201,23 @@ $bswp-status-indicator-size: 1.5rem;
         left: 2px;
         top: 2px;
         box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+      }
+
+      &.active {
+        background: $bswp-status-indicator-enabled;
+        cursor: pointer;
+
+        &::before {
+          left: auto;
+          right: 2px;
+          box-shadow: 0 3px 8px rgba(95, 204, 98, 0.8);
+        }
+      }
+    }
+
+    &.plugin-unavailable {
+      .bswp__addon__status-indicator {
+        cursor: not-allowed;
       }
     }
 
@@ -221,20 +238,6 @@ $bswp-status-indicator-size: 1.5rem;
       margin-bottom: 1.5rem;
     }
 
-    &.status-active {
-      // border: 2px solid $bswp-status-indicator-enabled;
-      // box-shadow: $bswp-status-enabled-shadow;
-
-      .bswp__addon__status-indicator {
-        background: $bswp-status-indicator-enabled;
-
-        &::before {
-          left: auto;
-          right: 2px;
-          box-shadow: 0 3px 8px rgba(95, 204, 98, 0.8);
-        }
-      }
-    }
   }
 
   &__checkbox {

--- a/includes/AddOns/AutomateWoo/AutomateWoo.php
+++ b/includes/AddOns/AutomateWoo/AutomateWoo.php
@@ -67,7 +67,7 @@ class AutomateWoo extends BetterSharingAddOn{
 	public function enqueue_scripts() {
 		global $post;
 
-		if ( $post->ID !== $this->referralsPage ) {
+		if ( $post && $post->ID !== $this->referralsPage ) {
 			return false;
 		}
 

--- a/includes/AddOns/CouponReferralProgram/CouponReferralProgram.php
+++ b/includes/AddOns/CouponReferralProgram/CouponReferralProgram.php
@@ -90,7 +90,7 @@ class CouponReferralProgram extends BetterSharingAddOn {
 	 */
 	public function remove_widget() {
 		global $wp_filter;
-		if ( is_array( $wp_filter[$this->hookName]->callbacks[10] ) ) {
+		if ( isset( $wp_filter[$this->hookName]->callbacks[10] ) && is_array( $wp_filter[$this->hookName]->callbacks[10] ) ) {
 			$key = key( $wp_filter[$this->hookName]->callbacks[10] );
 			if ( is_array( $wp_filter[$this->hookName]->callbacks[10][$key]['function'] ) ) {
 				if ( is_array( $wp_filter[$this->hookName]->callbacks[10][$key]['function'] ) ) {

--- a/includes/AdminScreens/AddOns.php
+++ b/includes/AdminScreens/AddOns.php
@@ -50,13 +50,10 @@ class AddOns {
     if ( !isset ( $_POST['__bswp_api_key__save'] ) ) {
       return;
     }
-
     if ( isset( $_POST['__bswp_api_key'] ) ) {
       $apiKeySaved = $this->save_api_key( sanitize_text_field( $_POST['__bswp_api_key'] ) );
-
       if ( is_wp_error( $apiKeySaved ) ) {
         $this->errorMsg = $apiKeySaved->get_error_message();
-
         add_action( 'admin_notices', function() {
           $class = 'notice notice-error';
           $message = $this->errorMsg;

--- a/includes/AdminScreens/admin-templates/addons-page.php
+++ b/includes/AdminScreens/admin-templates/addons-page.php
@@ -10,7 +10,15 @@ $addOns = AddOnsCore::getAddOns();
 <div class="bswp__container">
   <div class="bswp__addons">
     <?php foreach( $addOns as $addOn ) : ?>
-    <div class="card bswp__addon status-<?php echo $addOn->status; ?>">
+      <?php 
+        // Is Addon Active
+        $addonActive = 'active' === $addOn->status;
+        // Plugin is installed and activated - class
+        $pluginAvailableClass = $addOn->isPluginActive() ? 'plugin-available' : 'plugin-unavailable';
+        // AddOn is active status - class
+        $activeClass =  $addonActive && $addOn->isPluginActive() ? 'active' : 'inactive';
+      ?>
+    <div class="card bswp__addon <?php echo $pluginAvailableClass; ?>">
 
       <div class="bswp__addon__header">
         <h2 class="title bswp__addon__title"><?php echo $addOn->name; ?></h2>
@@ -18,20 +26,10 @@ $addOns = AddOnsCore::getAddOns();
         <!-- Toggle -->
         <div class="bswp__addon__status">
           <span class="bswp__addon__status-label">
-            <?php
-              if ( 'active' === $addOn->status && $addOn->isPluginActive() ) {
-                echo 'Active';
-              } elseif ( 'active' !== $addOn->status && $addOn->isPluginActive() ) {
-                echo 'Inactive';
-              } elseif ( !$addOn->isPluginActive() ) {
-                echo '';
-              }
-            ?>
+            <?php echo $activeClass; ?>
           </span>
-          <?php if ( $addOn->isPluginActive() ) : ?>
-          <div class="bswp__addon__status-indicator" data-addon="<?php echo $addOn->slug; ?>" data-status="<?php echo $addOn->status; ?>" data-plugin="<?php echo $addOn->isPluginActive() ? 'active' : 'inactive'; ?>">
-          </div>
-          <?php endif; ?>
+          <!-- toggle slider -->
+          <div class="bswp__addon__status-indicator <?php echo $activeClass; ?>" data-addon="<?php echo $addOn->slug; ?>" data-status="<?php echo $addOn->status; ?>" data-plugin="<?php echo $pluginAvailableClass; ?>"></div>
         </div>
         <!-- /Toggle -->
       </div>
@@ -62,11 +60,10 @@ $addOns = AddOnsCore::getAddOns();
       </div>
       <?php endif; ?>
 
-      <hr class="bswp__spacer">
-
       <!-- Settings Toggle -->
-      <?php if ( $addOn->hasSettings ) : ?>
-      <a class="btn button bswp__addon__settings-toggle" href="#" data-addon="<?php echo $addOn->slug; ?>">Settings</a>
+      <?php if ( $addOn->hasSettings && $addonActive) : ?>
+        <hr class="bswp__spacer">
+        <a class="btn button bswp__addon__settings-toggle" href="#" data-addon="<?php echo $addOn->slug; ?>">Settings</a>
       <?php endif; ?>
       <!-- / Settings Toggle -->
 

--- a/includes/templates/bswp-form.php
+++ b/includes/templates/bswp-form.php
@@ -5,6 +5,7 @@ $ajax = $ajax ? $ajax : false;
 $apiKey = get_site_option( '_bswp_option_core_apiKey', false );
 $emailSubject = $emailSubject ? $emailSubject : 'Sharing';
 $emailContent = $emailContent ? $emailContent : 'Email Content';
+$field_count = isset($field_count) ? absint( apply_filters( 'automatewoo/referrals/share_form/email_field_count', 5 ) ) : 5;
 
 $addOn = $addOn ? sanitize_title_with_dashes( $addOn ) : false;
 $actionData = [

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "license": "ISC",
   "scripts": {
     "clean": "rm -rf ./dist",
-    "build": "webpack -d --mode development",
-    "build:prod": "webpack -p --mode production"
+    "start": "webpack -d --mode development",
+    "build": "webpack -p --mode production"
   },
   "dependencies": {
     "react": "^16.13.1",

--- a/plugin.sh
+++ b/plugin.sh
@@ -1,0 +1,25 @@
+echo "" &&
+echo "======================================================" &&
+echo "WordPress Plugin Builder for Better Sharing for WP" &&
+echo "======================================================" &&
+echo "" &&
+
+#Ask & Store Version
+echo "Version Number";
+read -r versionNumber;
+
+
+# Create new branch
+git checkout -b build-"$versionNumber";
+
+# Run Build
+echo "Building version $versionNumber";
+#npm run build;
+
+#Create tag
+echo "Creating Tag";
+git tag -a v"$versionNumber" -m "new version: $versionNumber";
+
+#Push to GitHub
+echo "Pushing to GitHub";
+git push --tags origin;

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,11 @@
+=== Plugin Name ===
+Contributors: 
+Tags: sharing, cloud, address book
+Requires at least: 5.1
+Tested up to: 5.5.1
+Requires PHP: 7.2
+Stable tag: 1.1.0
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+ 
+Better Sharing WordPress plugin for use for CloudSponge


### PR DESCRIPTION
- Changed default functionality to show all addons, with inactive status (and not clickable) toggle
- 3 Addon States defined: `plugin activated & addon active`, `plugin activated & addon inactive`, `plugin not activated or installed`
- Changed npm scripts to `npm run start` and `npm run build` for dev & build respectively 