### PR TITLE
Feature/core block - email UI indications & copy link fix

### DIFF
--- a/blocks/block/modules/copyToClipboard.js
+++ b/blocks/block/modules/copyToClipboard.js
@@ -7,18 +7,19 @@ export default class copyToClipboard {
   }
 
   events() {
-    this.button.addEventListener('click', async (e) => {
-      if (!navigator.clipboard) {
-        // Clipboard API not available
-        return;
-      }
-      const text = this.input.value;
-      try {
-        await navigator.clipboard.writeText(text);
-        this.displaySuccessMsg();
-      } catch (err) {
-        console.error('Failed to copy!', err);
-      }
+    this.button.addEventListener('click', (e) => {
+      e.preventDefault();
+
+      const text = this.input;
+      text.select();
+      text.setSelectionRange(0, 99999);
+      document.execCommand('copy');
+
+      this.msg.style.display = 'block';
+
+      setTimeout(() => {
+        this.msg.style.display = 'none';
+      }, 1500);
     });
   }
 

--- a/blocks/block/modules/emailForm.js
+++ b/blocks/block/modules/emailForm.js
@@ -4,6 +4,10 @@ export default class emailForm {
     this.subject = document.getElementById('bswp-share-email-subject');
     this.message = document.getElementById('bswp-share-email-content');
     this.submit = document.querySelector('.bswp-submit');
+
+    this.errorMsg = document.querySelector('.coreblock-error-msg');
+    this.errorText = 'Error! Email not sent.';
+
     this.events();
   }
 
@@ -14,19 +18,54 @@ export default class emailForm {
   }
 
   submitMail(e) {
-    e.preventDefault()
+    e.preventDefault();
     const data = {
       emails: this.handleEmails(this.emailInput.value),
       subject: this.subject.value,
-      message: this.message.value
+      message: this.message.value,
     };
 
     const request = new XMLHttpRequest();
-    request.open('POST', `${window.location.origin}/wp-json/bswp/v1/bswp_email`, true);
-    request.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+    request.open(
+      'POST',
+      `${window.location.origin}/wp-json/bswp/v1/bswp_email`,
+      true
+    );
+    request.setRequestHeader(
+      'Content-Type',
+      'application/x-www-form-urlencoded; charset=UTF-8'
+    );
+    request.onreadystatechange = () => {
+      if (request.readyState === 4 && request.status === 200) {
+        const response = JSON.parse(request.responseText);
+        this.afterSubmit(response.mail);
+      }
+    };
     request.send(JSON.stringify(data));
   }
 
   // returns an array of emails from the input that were separated by a comma
   handleEmails = (emails) => emails.split(',').map((email) => email.trim());
+
+  // indicate in the UI if emails sent successfully or not.
+  afterSubmit = (response) => {
+    if (response) {
+      this.submit.value = 'Success!';
+      this.submit.disabled = true;
+      this.submit.style.backgroundColor = 'green';
+      this.submit.style.color = 'white';
+      setTimeout(() => {
+        this.submit.value = 'Send';
+        this.submit.disabled = false;
+        this.submit.style = 'inherit';
+      }, 3000);
+    } else {
+      this.errorMsg.innerText = this.errorText;
+      this.errorMsg.style.display = 'block';
+      setTimeout(() => {
+        this.errorMsg.innerText = '';
+        this.errorMsg.style.display = 'none';
+      }, 3000);
+    }
+  };
 }

--- a/blocks/block/style.scss
+++ b/blocks/block/style.scss
@@ -82,6 +82,12 @@
         width: 54%;
       }
     }
+
+    & .coreblock-error-msg {
+      display: none;
+      margin-top: 5px;
+      color: red;
+    }
   }
   
   .bswp-share-email-preview {

--- a/includes/templates/bswp-form.php
+++ b/includes/templates/bswp-form.php
@@ -78,6 +78,7 @@ do_action( 'bwp_form_before', $action_data );
 	<?php else : ?>
 		<div class="bswp-share-buttons">
 			<input type="submit" class="bswp-submit btn button" value="<?php echo 'Send'; ?>" />
+			<p class='coreblock-error-msg'></p>
 		</div>
 	<?php endif; ?>
 


### PR DESCRIPTION
When you hit submit to send an email from the coreblock it will either temporarily output a text error message below the submit button or temporarily turn the submit button green and change text to 'success', based on the response of wp_mail(). Also fixed copy referral link to clipboard. 