### PR TITLE
72 - Feature/core block - shortcode output

### DIFF
--- a/blocks/block/modules/emailForm.js
+++ b/blocks/block/modules/emailForm.js
@@ -58,6 +58,7 @@ export default class emailForm {
         this.submit.value = 'Send';
         this.submit.disabled = false;
         this.submit.style = 'inherit';
+        this.emailInput.value = '';
       }, 3000);
     } else {
       this.errorMsg.innerText = this.errorText;

--- a/includes/CoreBlocks.php
+++ b/includes/CoreBlocks.php
@@ -59,15 +59,6 @@ class CoreBlocks {
 	}
 
 	/**
-	 * Register shortcode.
-	 *
-	 * @return void
-	 */
-	public function add_better_sharing_shortcode() {
-		add_shortcode( 'better-sharing', array( $this, 'render_better_sharing_output' ) );
-	}
-
-	/**
 	 * Public Scripts and Styles
 	 *
 	 * @return void
@@ -103,7 +94,7 @@ class CoreBlocks {
 			'cgb/block-ea-better-sharing',
 			array(
 				'editor_script'   => 'better-sharing-blocks',
-				'render_callback' => array( $this, 'render_better_sharing_output' ),
+				'render_callback' => array( $this, 'better_sharing_output' ),
 				// default attributes if not contained within $block_attributes.
 				'attributes'      => array(
 					'emailFormControl'    => array(
@@ -120,6 +111,15 @@ class CoreBlocks {
 	}
 
 	/**
+	 * Register shortcode.
+	 *
+	 * @return void
+	 */
+	public function add_better_sharing_shortcode() {
+		add_shortcode( 'better-sharing', array( $this, 'better_sharing_output' ) );
+	}
+
+	/**
 	 * Create intent url for shortcode.
 	 *
 	 * @param string $intent_url Social sharing intent URL w/o permalink.
@@ -131,32 +131,39 @@ class CoreBlocks {
 	}
 
 	/**
-	 * Render Block
+	 * Render output.
 	 *
-	 * @param array  $block_attributes block attributes.
+	 * @param array  $atts block attributes.
 	 * @param string $content post content.
+	 * @param string $tag shortcode tag.
 	 *
 	 * @return string
 	 */
-	public function render_better_sharing_output( $block_attributes, $content ) {
-		// use default attributes for shortcode.
-		if ( '' === $block_attributes ) {
-			$block_attributes = $this->block_attributes;
+	public function better_sharing_output( $atts, $content = null, $tag = null ) {
+		// normalize attributes between gute block and shortcode.
+		$block_attributes = array_change_key_case( $atts, CASE_LOWER );
+
+		// add user attributes / default attributes if shortcode is used.
+		if ( 'better-sharing' === $tag ) {
+			$block_attributes = shortcode_atts(
+				array_change_key_case( $this->block_attributes, CASE_LOWER ),
+				$block_attributes
+			);
 		}
 
-		$social_networks = $block_attributes['socialNetworks'];
-		$referral_link   = array_key_exists( 'referralLink', $block_attributes ) ? esc_url( $block_attributes['referralLink'] ) : false;
-		$email_control   = sanitize_text_field( $block_attributes['emailFormControl'] );
+		$social_networks = $block_attributes['socialnetworks'];
+		$referral_link   = array_key_exists( 'referrallink', $block_attributes ) ? esc_url( $block_attributes['referrallink'] ) : get_permalink();
+		$email_control   = sanitize_text_field( $block_attributes['emailformcontrol'] );
 
 		// replace '{{link}}' with actual link.
-		$email_content = sanitize_text_field( $block_attributes['emailMessage'] );
+		$email_content = sanitize_text_field( $block_attributes['emailmessage'] );
 		$email_content = str_replace( '{{link}}', $referral_link, $email_content );
 
 		// used in bswp-form.
 		$addon                = 'core';
 		$ajax                 = false;
-		$link_control         = sanitize_text_field( $block_attributes['referralLinkControl'] );
-		$email_subject        = sanitize_text_field( $block_attributes['emailSubject'] );
+		$link_control         = sanitize_text_field( $block_attributes['referrallinkcontrol'] );
+		$email_subject        = sanitize_text_field( $block_attributes['emailsubject'] );
 		$preview_email_toggle = false;
 
 		// whether or not email form is rendered.

--- a/includes/CoreBlocks.php
+++ b/includes/CoreBlocks.php
@@ -13,9 +13,59 @@ namespace BetterSharingWP;
 class CoreBlocks {
 
 	/**
+	 * Message to share with social share links.
+	 *
+	 * @var string $message Message.
+	 */
+	public $message;
+
+	/**
+	 * Default block attributes for shortcode output
+	 *
+	 * @var array  $block_attributes block attributes.
+	 */
+	public $block_attributes;
+
+	/**
 	 * Constructor
 	 */
-	public function __construct() {}
+	public function __construct() {
+		$this->message = 'Check out this link!';
+
+		$this->block_attributes = array(
+			'emailSubject'        => 'Sharing',
+			'emailMessage'        => 'What a great way to save! Click {{link}}',
+			'socialNetworks'      => array(
+				'twitter'  => array(
+					'visible'   => true,
+					'name'      => 'Twitter',
+					'icon'      => 'twitter',
+					'message'   => $this->message,
+					'intentUrl' => 'https://www.twitter.com/intent/tweet?url={{permalink}}&text=' . $this->message,
+				),
+				'facebook' => array(
+					'visible'   => true,
+					'name'      => 'Facebook',
+					'icon'      => 'facebook',
+					'message'   => 'No custom message available',
+					'intentUrl' => 'https://www.facebook.com/sharer/sharer.php?&u={{permalink}}',
+				),
+			),
+			'emailFormControl'    => 'readonly',
+			'referralLinkControl' => 'default',
+		);
+
+		add_action( 'init', array( $this, 'add_better_sharing_shortcode' ) );
+	}
+
+	/**
+	 * Register shortcode.
+	 *
+	 * @return void
+	 */
+	public function add_better_sharing_shortcode() {
+		add_shortcode( 'better-sharing', array( $this, 'render_better_sharing_output' ) );
+	}
 
 	/**
 	 * Public Scripts and Styles
@@ -23,7 +73,8 @@ class CoreBlocks {
 	 * @return void
 	 */
 	public function core_block_public_scripts() {
-		if ( has_block( 'cgb/block-ea-better-sharing' ) ) {
+		global $post;
+		if ( has_block( 'cgb/block-ea-better-sharing' ) || has_shortcode( $post->post_content, 'better-sharing' ) ) {
 			wp_enqueue_script(
 				'better-sharing-blocks-public',
 				BETTER_SHARING_URI . 'dist/blocks/public.bundle.js',
@@ -52,7 +103,7 @@ class CoreBlocks {
 			'cgb/block-ea-better-sharing',
 			array(
 				'editor_script'   => 'better-sharing-blocks',
-				'render_callback' => array( $this, 'render_block' ),
+				'render_callback' => array( $this, 'render_better_sharing_output' ),
 				// default attributes if not contained within $block_attributes.
 				'attributes'      => array(
 					'emailFormControl'    => array(
@@ -69,6 +120,17 @@ class CoreBlocks {
 	}
 
 	/**
+	 * Create intent url for shortcode.
+	 *
+	 * @param string $intent_url Social sharing intent URL w/o permalink.
+	 *
+	 * @return string
+	 */
+	public function create_intent_url( $intent_url ) {
+		return str_replace( '{{permalink}}', get_permalink(), $intent_url );
+	}
+
+	/**
 	 * Render Block
 	 *
 	 * @param array  $block_attributes block attributes.
@@ -76,12 +138,17 @@ class CoreBlocks {
 	 *
 	 * @return string
 	 */
-	public function render_block( $block_attributes, $content ) {
+	public function render_better_sharing_output( $block_attributes, $content ) {
+		// use default attributes for shortcode.
+		if ( '' === $block_attributes ) {
+			$block_attributes = $this->block_attributes;
+		}
+
 		$social_networks = $block_attributes['socialNetworks'];
-		$referral_link   = esc_url_raw( $block_attributes['referralLink'] );
+		$referral_link   = array_key_exists( 'referralLink', $block_attributes ) ? esc_url( $block_attributes['referralLink'] ) : false;
 		$email_control   = sanitize_text_field( $block_attributes['emailFormControl'] );
 
-			// replace '{{link}}' with actual link.
+		// replace '{{link}}' with actual link.
 		$email_content = sanitize_text_field( $block_attributes['emailMessage'] );
 		$email_content = str_replace( '{{link}}', $referral_link, $email_content );
 
@@ -109,7 +176,7 @@ class CoreBlocks {
 				$icon       = $network['icon'];
 				$intent_url = $network['intentUrl'];
 
-				echo '<a key="' . esc_attr( $key ) . '" href="' . esc_url_raw( $intent_url ) . '" target="_blank" ref="noopener noreferrer">';
+				echo '<a key="' . esc_attr( $key ) . '" href="' . esc_url( $this->create_intent_url( $intent_url ) ) . '" target="_blank" ref="noopener noreferrer">';
 				echo '<button class="components-button is-secondary is-small has-text has-icon">';
 				echo '<span class="dashicons dashicons-' . esc_attr( $icon ) . '"></span>&nbsp;';
 				echo esc_html( $name );
@@ -125,7 +192,7 @@ class CoreBlocks {
 		?>
 		<div class='referral-link'>
 			<label for='referral-link'>Your referral link</label>
-			<input type='text' id='referral-link' value='<?php echo esc_attr( $referral_link ); ?>' readOnly>
+			<input type='text' id='referral-link' value='<?php echo esc_attr( $referral_link ? $referral_link : get_permalink() ); ?>' readOnly>
 			<button class="components-button is-secondary is-small has-text has-icon" icon='admin-page' id='referral-btn-copy'>
 				Copy Link
 			</button>

--- a/includes/CoreBlocks.php
+++ b/includes/CoreBlocks.php
@@ -32,9 +32,11 @@ class CoreBlocks {
 	public function __construct() {
 		$this->message = 'Check out this link!';
 
-		$this->block_attributes = array(
+		$this->shortcode_attributes = array(
 			'emailSubject'        => 'Sharing',
 			'emailMessage'        => 'What a great way to save! Click {{link}}',
+			'twitter'             => 'true',
+			'facebook'            => 'true',
 			'socialNetworks'      => array(
 				'twitter'  => array(
 					'visible'   => true,
@@ -146,9 +148,18 @@ class CoreBlocks {
 		// add user attributes / default attributes if shortcode is used.
 		if ( 'better-sharing' === $tag ) {
 			$block_attributes = shortcode_atts(
-				array_change_key_case( $this->block_attributes, CASE_LOWER ),
+				array_change_key_case( $this->shortcode_attributes, CASE_LOWER ),
 				$block_attributes
 			);
+
+			// shortcode options to remove social network sharing.
+			if ( 'false' === $block_attributes['twitter'] ) {
+				unset( $block_attributes['socialnetworks']['twitter'] );
+			}
+
+			if ( 'false' === $block_attributes['facebook'] ) {
+				unset( $block_attributes['socialnetworks']['facebook'] );
+			}
 		}
 
 		$social_networks = $block_attributes['socialnetworks'];

--- a/includes/CoreBlocks.php
+++ b/includes/CoreBlocks.php
@@ -147,12 +147,11 @@ class CoreBlocks {
 
 		// add user attributes / default attributes if shortcode is used.
 		if ( 'better-sharing' === $tag ) {
-			if ( true === is_array( $block_attributes ) ) {
-				$block_attributes = shortcode_atts(
-					array_change_key_case( $this->shortcode_attributes, CASE_LOWER ),
-					$block_attributes
-				);
-			}
+			$block_attributes = shortcode_atts(
+				array_change_key_case( $this->shortcode_attributes, CASE_LOWER ),
+				$block_attributes
+			);
+
 			// shortcode options to remove social network sharing.
 			if ( 'false' === $block_attributes['twitter'] ) {
 				unset( $block_attributes['socialnetworks']['twitter'] );

--- a/includes/CoreBlocks.php
+++ b/includes/CoreBlocks.php
@@ -147,11 +147,12 @@ class CoreBlocks {
 
 		// add user attributes / default attributes if shortcode is used.
 		if ( 'better-sharing' === $tag ) {
-			$block_attributes = shortcode_atts(
-				array_change_key_case( $this->shortcode_attributes, CASE_LOWER ),
-				$block_attributes
-			);
-
+			if ( true === is_array( $block_attributes ) ) {
+				$block_attributes = shortcode_atts(
+					array_change_key_case( $this->shortcode_attributes, CASE_LOWER ),
+					$block_attributes
+				);
+			}
 			// shortcode options to remove social network sharing.
 			if ( 'false' === $block_attributes['twitter'] ) {
 				unset( $block_attributes['socialnetworks']['twitter'] );

--- a/includes/CoreBlocks.php
+++ b/includes/CoreBlocks.php
@@ -143,7 +143,11 @@ class CoreBlocks {
 	 */
 	public function better_sharing_output( $atts, $content = null, $tag = null ) {
 		// normalize attributes between gute block and shortcode.
-		$block_attributes = array_change_key_case( $atts, CASE_LOWER );
+		if ( true === is_array( $atts ) ) {
+			$block_attributes = array_change_key_case( $atts, CASE_LOWER );
+		} else {
+			$block_attributes = $atts;
+		}
 
 		// add user attributes / default attributes if shortcode is used.
 		if ( 'better-sharing' === $tag ) {


### PR DESCRIPTION
I have updated the CoreBlock so it can now be output with shortcode as well. [better-sharing] is the shortcode, and it is set with the following default attributes if none are provided:

```
$this->shortcode_attributes = array(
			'emailSubject'        => 'Sharing',
			'emailMessage'        => 'What a great way to save! Click {{link}}',
			'twitter'             => 'true',
			'facebook'            => 'true',
			'socialNetworks'      => array(
				'twitter'  => array(
					'visible'   => true,
					'name'      => 'Twitter',
					'icon'      => 'twitter',
					'message'   => $this->message,
					'intentUrl' => 'https://www.twitter.com/intent/tweet?url={{permalink}}&text=' . $this->message,
				),
				'facebook' => array(
					'visible'   => true,
					'name'      => 'Facebook',
					'icon'      => 'facebook',
					'message'   => 'No custom message available',
					'intentUrl' => 'https://www.facebook.com/sharer/sharer.php?&u={{permalink}}',
				),
			),
			'emailFormControl'    => 'readonly',
			'referralLinkControl' => 'default',
		);
```

So, if you wish to put in a custom email subject and message, it would look like [better-sharing emailsubject='This is a custom email subject!' emailmessage='Check out this custom {{link}}']

*The attributes are all converted to lowercase so they are case insensitive. emailSubject, EMAILSUBJECT, emailsubject, etc. will all work fine.

The social network share buttons are a little tricky to customize since their data is in nested arrays right now, but you are able to turn them on or off e.g. [better-sharing facebook='false'] will only show the Twitter button. I will need to add the ability to customize the Twitter share message if desired.

emailFormControl and referralLinkControl can be set to 'hidden'.

Also updated so the email input is cleared after emails sent successfully.